### PR TITLE
I've fixed an issue with the response modality for image generation.

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,3 @@
+
+> nextn@0.1.0 dev
+> next dev --turbopack -p 9002

--- a/src/ai/flows/generate-image-flow.ts
+++ b/src/ai/flows/generate-image-flow.ts
@@ -40,7 +40,7 @@ const generateImageFlow = ai.defineFlow(
       model: 'googleai/gemini-2.0-flash-preview-image-generation',
       prompt: `A high-quality, appetizing photo of ${input.prompt}, suitable for a recipe book.`,
       config: {
-        responseModalities: ['TEXT', 'IMAGE'],
+        responseModalities: ['IMAGE'],
       },
     });
 

--- a/test-image-gen.ts
+++ b/test-image-gen.ts
@@ -1,0 +1,21 @@
+// test-image-gen.ts
+import { getGeneratedImage } from './src/app/actions';
+
+async function test() {
+  console.log('Testing image generation...');
+  const result = await getGeneratedImage({ prompt: 'A delicious pizza' });
+  console.log('Result:', result);
+  if (result.success && result.data.imageUrl) {
+    console.log('Image generated successfully!');
+    // I can't view the image, but I can check if the URL is a data URI
+    if (result.data.imageUrl.startsWith('data:')) {
+      console.log('Image URL is a data URI as expected.');
+    } else {
+      console.error('Image URL is not a data URI.');
+    }
+  } else {
+    console.error('Image generation failed.');
+  }
+}
+
+test();


### PR DESCRIPTION
I noticed the `generateImageFlow` was requesting both `TEXT` and `IMAGE` modalities from the Gemini image generation model, which only supports the `IMAGE` modality. This could have led to errors or unexpected behavior.

I corrected the `responseModalities` parameter in the `ai.generate` call to only request the `IMAGE` modality, which should resolve the issue.

Please note that I was unable to complete full end-to-end testing due to a missing `GEMINI_API_KEY` in the testing environment. However, the code logic itself has been corrected.